### PR TITLE
fix: Move the "Donate" link to the right side in the footer

### DIFF
--- a/components/footer/index.tsx
+++ b/components/footer/index.tsx
@@ -30,7 +30,6 @@ export default function Footer() {
           <Link href="/#about">About us</Link>
           <Link href="/#contribute">Programming Languages</Link>
           <Link href="/#contribute">Contribute</Link>
-          <Link href="/#contribute">Donate</Link>
           <Link href="https://github.com/TheAlgorithms/website">
             Source code
           </Link>
@@ -40,6 +39,7 @@ export default function Footer() {
           <Link href="https://gitter.im/TheAlgorithms/">Gitter</Link>
           <Link href="https://twitter.com/The_Algorithms">Twitter</Link>
           <Link href="/all">All algorithms</Link>
+          <Link href="/#contribute">Donate</Link>
         </div>
         <a
           className={classes.vercelLogo}

--- a/components/footer/index.tsx
+++ b/components/footer/index.tsx
@@ -30,16 +30,16 @@ export default function Footer() {
           <Link href="/#about">About us</Link>
           <Link href="/#contribute">Programming Languages</Link>
           <Link href="/#contribute">Contribute</Link>
-          <Link href="https://github.com/TheAlgorithms/website">
-            Source code
-          </Link>
+          <Link href="/#contribute">Donate</Link>
         </div>
         <div className={classes.list}>
           <Link href="https://github.com/TheAlgorithms/">GitHub</Link>
           <Link href="https://gitter.im/TheAlgorithms/">Gitter</Link>
           <Link href="https://twitter.com/The_Algorithms">Twitter</Link>
           <Link href="/all">All algorithms</Link>
-          <Link href="/#contribute">Donate</Link>
+          <Link href="https://github.com/TheAlgorithms/website">
+            Source code
+          </Link>
         </div>
         <a
           className={classes.vercelLogo}


### PR DESCRIPTION
Things added/changed:

- Move the "Donate" link to the right side in the footer.
  - I think it looks better on the right side because, on the left side, there are already too many links.

Before:

![Before](https://user-images.githubusercontent.com/51391473/109556967-15da1500-7a9d-11eb-93f0-baf567c1162f.png)

After:

![After](https://user-images.githubusercontent.com/51391473/109556906-04910880-7a9d-11eb-810f-0867adaa1ce1.png)
