### PR TITLE
Fix too long algorithm name wrapping on card

### DIFF
--- a/components/algorithmsList/algorithmCard/index.tsx
+++ b/components/algorithmsList/algorithmCard/index.tsx
@@ -5,6 +5,7 @@ import {
   CardActions,
   Button,
   Breadcrumbs,
+  Tooltip,
 } from "@material-ui/core";
 import React from "react";
 import Implementations from "components/implementations";
@@ -34,9 +35,17 @@ export default function AlgorithmCard({ algorithm }: { algorithm: Algorithm }) {
             </Typography>
           ))}
         </Breadcrumbs>
-        <Typography variant="h5" component="h2" className={classes.title}>
-          {algorithm.name}
-        </Typography>
+        {algorithm.name.length > 26 ? (
+          <Tooltip title={algorithm.name}>
+            <Typography variant="h5" component="h2" className={classes.title}>
+              {algorithm.name}
+            </Typography>
+          </Tooltip>
+        ) : (
+          <Typography variant="h5" component="h2" className={classes.title}>
+            {algorithm.name}
+          </Typography>
+        )}
       </CardContent>
       <CardActions className={classes.actions}>
         <Implementations implementations={algorithm.implementations} />

--- a/components/algorithmsList/algorithmCard/style.module.css
+++ b/components/algorithmsList/algorithmCard/style.module.css
@@ -4,6 +4,24 @@
 
 .title {
   margin-bottom: 10px;
+  overflow: hidden;
+  white-space: nowrap;
+  position: relative;
+}
+
+.title::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 25px;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 1) 100%
+  );
+  pointer-events: none;
 }
 
 .actions {


### PR DESCRIPTION
<!-- Add the number of the issue this pull request is closing here -->
Closes #97 

<!-- Description of the changes this pull request introduces -->
**What change does this pull request introduce?**
Hides too long algorithm name and adds a tooltip instead of wrapping it.

<!-- If applicable, include screenshots of the issue you solved -->
**Screenshots**
Before:
![1](https://user-images.githubusercontent.com/48161361/121790092-6fd59500-cbcb-11eb-9252-5def17a114b7.png)

After:
![2](https://user-images.githubusercontent.com/48161361/121790093-706e2b80-cbcb-11eb-8436-0e0003da7ff3.png)
![3](https://user-images.githubusercontent.com/48161361/121790094-7106c200-cbcb-11eb-8215-88c07e02eb88.png)


**Checklist**

- [x] I worked on a branch other than `main`.
- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] I have fixed potential errors using `yarn lint`.
- [x] I ran `yarn build` to check everything still builds successfully.
