### PR TITLE
feat(playground): load packages and add xterm

### DIFF
--- a/components/playgroundEditor/style.module.css
+++ b/components/playgroundEditor/style.module.css
@@ -5,16 +5,22 @@
 
 .editor {
   position: relative;
-  width: 70vw;
+  width: 65vw;
 }
 
 .output {
   background-color: black;
   color: white;
   padding: 10px;
-  width: 30vw;
+  width: 35vw;
   overflow-y: auto;
   margin: 0;
+  height: 100%;
+}
+
+.xterm {
+  width: 100%;
+  height: 100%;
 }
 
 @media (max-aspect-ratio: 1/1) {
@@ -25,7 +31,7 @@
   .editor {
     position: relative;
     width: auto;
-    height: 70%;
+    height: 65%;
   }
 
   .output {
@@ -33,7 +39,7 @@
     color: white;
     padding: 7px;
     width: auto;
-    height: 30%;
+    height: 35%;
     overflow-y: auto;
     margin: 0;
   }

--- a/lib/pyodide.ts
+++ b/lib/pyodide.ts
@@ -3,9 +3,10 @@ import { loadPyodide } from "lib/pyodide/pyodide";
 let pyodide;
 
 export default async function tryLoadPyodide() {
-  if (!pyodide)
+  if (!pyodide) {
     pyodide = await loadPyodide({
       indexURL: "https://cdn.jsdelivr.net/pyodide/v0.18.0/full/",
     });
+  }
   return pyodide;
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "remark-rehype": "<9.0.0",
     "sanitize-html": "^2.5.2",
     "title-case": "^3.0.3",
-    "unified": "<10.0.0"
+    "unified": "<10.0.0",
+    "xterm-addon-fit": "^0.5.0",
+    "xterm-for-react": "^1.0.4"
   },
   "devDependencies": {
     "@babel/core": "^7.15.8",

--- a/pages/playground.tsx
+++ b/pages/playground.tsx
@@ -74,7 +74,7 @@ export default function CodePlayground() {
         const githubCode = (await githubResponse.text())
           // Remove doctest because it doesn't work with pyodide
           .replace(/[ \t]*import doctest *\n{1,2}/g, "")
-          .replace(/[ \t]*doctest.testmod\(\) *\n{1,2}/g, "");
+          .replace(/[ \t]*doctest\.testmod\(.*\).*\n{1,2}/g, "");
         const newId = createNewPlayground(languageParam, githubCode);
         setTimeout(() => router.replace(`/playground?id=${newId}`));
       })();

--- a/public/locales/en/categories.json
+++ b/public/locales/en/categories.json
@@ -160,6 +160,7 @@
     "sequences": "Sequences",
     "series": "Series",
     "sieveoferatosthenes": "Sieve of Eratosthenes",
+    "slidingwindow": "Sliding Window",
     "sorts": "Sorts",
     "spanningtree": "Spanning Tree",
     "stablemarriage": "Stable Marriage",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -73,9 +73,11 @@
   "codeplayground": "Code Playground",
   "playgroundRunCode": "Run Code",
   "playgroundTryCode": "Try this Code",
-  "playgroundWelcome": "Welcome to the Python Code Playground 👋\n\nGet started by editing the code on the left\nside of the screen and clicking \"Run code\"",
+  "playgroundWelcome": "Welcome to the Python Code Playground 👋",
   "playgroundUnsupported": "Your browser does not support Web Assembly\nand can thus not run the code.\n\nYou can still edit the code on the left.",
   "playgroundErrIdNotFound": "The Playground ID was not found",
   "playgroundErrInvalidLink": "The Playground Link is invalid",
-  "aboutThisAlgorithm": "About this Algorithm"
+  "aboutThisAlgorithm": "About this Algorithm",
+  "playgroundLoadingPackage": "Loading {package}",
+  "playgroundReady": "Ready! Get started by editing the code on the\nleft side of the screen and clicking \"Run code\""
 }

--- a/scripts/fetch-algorithms.ts
+++ b/scripts/fetch-algorithms.ts
@@ -43,6 +43,8 @@ let authors: {
 } = {};
 let spinner: Ora;
 
+// Algorithms which are ignored
+const algorithmsToIgnore = ["rungradientdescent"];
 // Categories where algorithms are ignored
 const categoriesToIgnore = [
   "projecteuler",
@@ -102,6 +104,7 @@ const categoriesToSkip = ["main", "src", "algorithms", "problems"];
         dir.split(path.sep).pop().split(".")[0].replace(/_/g, " ")
       );
       const nName = normalize(name);
+      if (algorithmsToIgnore.includes(nName)) continue;
       const lCategories = dir
         .split(path.sep)
         .slice(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5184,6 +5184,24 @@ xtend@^4.0.0, xtend@^4.0.2:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
+xterm-addon-fit@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.5.0.tgz#2d51b983b786a97dcd6cde805e700c7f913bc596"
+  integrity sha512-DsS9fqhXHacEmsPxBJZvfj2la30Iz9xk+UKjhQgnYNkrUIN5CYLbw7WEfz117c7+S86S/tpHPfvNxJsF5/G8wQ==
+
+xterm-for-react@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/xterm-for-react/-/xterm-for-react-1.0.4.tgz#6b35b9b037a0f9d979e7b57bb1d7c6ab7565b380"
+  integrity sha512-DCkLR9ZXeW907YyyaCTk/3Ol34VRHfCnf3MAPOkj3dUNA85sDqHvTXN8efw4g7bx7gWdJQRsEpGt2tJOXKG3EQ==
+  dependencies:
+    prop-types "^15.7.2"
+    xterm "^4.5.0"
+
+xterm@^4.5.0:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.14.1.tgz#6884cb8fb3b83353b1a98139ea23daedf8e35796"
+  integrity sha512-jgzNg5BuGPwq5/M4dGnmbghZvHx2jaj+9crSEt15bV34Za49VziBmCu7zIy88zUKKiGTxeo7aVzirFSJArIMFw==
+
 yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"


### PR DESCRIPTION
<!-- Description of the changes this pull request introduces -->
**What change does this pull request introduce?**

This pull request updated the playground terminal to use [xterm](https://xtermjs.org/). The playground will now also automatically load required packages like `numpy`, which will fix #130.


<!-- If applicable, include screenshots of the issue you solved -->
**Screenshots**

https://user-images.githubusercontent.com/48161361/140418772-855e12ba-bce2-465e-8fd7-9f0233c314cd.mp4
