### PR TITLE
Replace all `discord.gg` instances with new link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Discord community
-    url: https://discord.gg/c7MnfGFGa6
+    url: https://the-algorithms.com/discord/
     about: Have any questions or found any bugs? Please contact us via Discord

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
     <img src="https://github.com/TheAlgorithms/website/actions/workflows/codeql-analysis.yml/badge.svg" height="20">
   </a>
 
-  <a href="https://discord.gg/c7MnfGFGa6">
+  <a href="https://the-algorithms.com/discord/">
     <img src="https://img.shields.io/discord/808045925556682782.svg?logo=discord&colorB=5865F2" height="20">
   </a>
 

--- a/components/editPage/addExplanation/index.tsx
+++ b/components/editPage/addExplanation/index.tsx
@@ -33,7 +33,7 @@ export default function AddExplanation({
         <Typography className={classes.paragraph}>
           <Translation
             name="editPageHelp"
-            links={["https://discord.gg/c7MnfGFGa6"]}
+            links={["https://the-algorithms.com/discord/"]}
           />
         </Typography>
       </DialogContent>

--- a/components/editPage/addTranslation/index.tsx
+++ b/components/editPage/addTranslation/index.tsx
@@ -45,7 +45,7 @@ export default function AddTranslation({
         <Typography className={classes.paragraph}>
           <Translation
             name="editPageHelp"
-            links={["https://discord.gg/c7MnfGFGa6"]}
+            links={["https://the-algorithms.com/discord/"]}
           />
         </Typography>
       </DialogContent>

--- a/pages/[shortlink].tsx
+++ b/pages/[shortlink].tsx
@@ -7,7 +7,7 @@ export default function Shortlink() {
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const URLs = {
-    discord: "https://discord.gg/c7MnfGFGa6",
+    discord: "https://the-algorithms.com/discord/",
   };
   if (context.params.shortlink && URLs[context.params.shortlink.toString()])
     return {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -292,7 +292,7 @@ export default function Home({
             <Tooltip title={t("socialDiscord")}>
               <Card>
                 <IconButton
-                  href="https://discord.gg/c7MnfGFGa6"
+                  href="https://the-algorithms.com/discord/"
                   target="_blank"
                   rel="noreferrer"
                   aria-label={t("socialDiscord")}


### PR DESCRIPTION
<!-- Add the number of the issue this pull request is closing here -->
Closes #181

<!-- Description of the changes this pull request introduces -->
**What change does this pull request introduce?**

This PR replaces all `discord.gg` instances with new link `https://the-algorithms.com/discord/`. All files containing `discord.gg` link (shown in screenshot) have been edited to replace those links.

<!-- If applicable, include screenshots of the issue you solved -->
**Screenshots**

![submit](https://user-images.githubusercontent.com/62293137/192162914-b095d05a-0084-436e-bed6-b1502ff79a33.PNG)


**Checklist**

- [x] I worked on a branch other than `main`.
- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] I have fixed potential errors using `yarn lint`.
- [x] I ran `yarn build` to check everything still builds successfully.


<a href="https://gitpod.io/#https://github.com/TheAlgorithms/website/pull/182"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

