### PR TITLE
[BUG]fix: invalid link generator for `C#` codes.

### DIFF
--- a/scripts/fetch-algorithms.ts
+++ b/scripts/fetch-algorithms.ts
@@ -226,10 +226,7 @@ const categoriesToSkip = ["main", "src", "algorithms", "problems"];
               }
               algorithms[nName].implementations["c-sharp"] = {
                 dir,
-                url: path.join(
-                  "https://github.com/TheAlgorithms/C-Sharp/tree/master",
-                  algorithmMatch[2]
-                ),
+                url: `https://github.com/TheAlgorithms/C-Sharp/tree/master${algorithmMatch[2].slice(1)}`,
                 code: highlightCode(file, "c-sharp"),
               };
             } else if (categoryMatch) {


### PR DESCRIPTION
**Issue**
Due to invalid GitHub code URL generator for `C#` Codes, when we select `C#` and then click on `View on GitHub` Button, we always direct to `404 page`.
![Screenshot from 2022-10-02 00-28-08](https://user-images.githubusercontent.com/82411321/193470648-9ef2caba-3cdb-4c8f-b28f-cf8f000e46e4.png)


**Reason**
The browser is **prepending** the Base URL to invalid href.![demo](https://user-images.githubusercontent.com/82411321/193470694-b450db55-a818-4aeb-add7-03c5e6e6866b.png)

**Couse of Issue** 
In file `scripts/fetch-algorithms.ts` this code is used to fetch the URLs.
```cs
url: path.join(
   "https://github.com/TheAlgorithms/C-Sharp/tree/master",
    algorithmMatch[2]
),
```
To maintain the forward-slash `/` for entire string, `path.join` is removing one `/` from `https://github.com` making is `https:/github.com` thus making the entire URL invalid.

**Fix**
```cs
url: `https://github.com/TheAlgorithms/C-Sharp/tree/master${algorithmMatch[2].slice(1)}`;
```
**algorithmMatch[2]** is like `./Algorithms/Graph/DepthFirstSearch.cs`
then **algorithmMatch[2].slice(1)** will be `/Algorithms/Graph/DepthFirstSearch.cs` i.e remove the starting `.`
and the final string become `https://github.com/TheAlgorithms/C-Sharp/tree/master/Algorithms/Graph/DepthFirstSearch.cs`

**Checklist**

- [x] I worked on a branch other than `main`.
- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] I have fixed potential errors using `yarn lint`.
- [x] I ran `yarn build` to check everything still builds successfully.


<a href="https://gitpod.io/#https://github.com/TheAlgorithms/website/pull/191"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

