### PR TITLE
Add Sudoku and Sudoku Solver as an alias

### DIFF
--- a/lib/aliases.ts
+++ b/lib/aliases.ts
@@ -49,6 +49,8 @@ const aliases = {
     isarmstrong: "Armstrong Number",
     xor: "XOR Cipher",
     xorcipher: "XOR Cipher",
+    sudoku: "Sudoku Solver",
+    sudokusolver: "Sudoku Solver",
   },
   categories: {
     sorting: "Sorts",


### PR DESCRIPTION
<!-- Description of the changes this pull request introduces -->
**What change does this pull request introduce?**

- Add Sudoku and Sudoku Solver as an alias.

<!-- If applicable, include screenshots of the issue you solved -->
**Screenshots**

**Checklist**

- [x] I worked on a branch other than `main`.
- [x] My branch is up-to-date with the Upstream `main` branch.
- [ ] I have fixed potential errors using `yarn lint`.
- [ ] I ran `yarn build` to check everything still builds successfully.


<a href="https://gitpod.io/#https://github.com/TheAlgorithms/website/pull/201"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

