### PR TITLE
Set same height for all algo cards in same row

### DIFF
--- a/components/algorithmsList/algorithmCard/index.tsx
+++ b/components/algorithmsList/algorithmCard/index.tsx
@@ -20,7 +20,7 @@ export default function AlgorithmCard({ algorithm }: { algorithm: Algorithm }) {
   const t = useTranslation();
 
   return (
-    <Card className="elevateOnHover">
+    <Card className={`elevateOnHover ${classes.stretchedCard}`}>
       <CardContent>
         <Breadcrumbs>
           {algorithm.categories.map((category) => (

--- a/components/algorithmsList/algorithmCard/style.module.css
+++ b/components/algorithmsList/algorithmCard/style.module.css
@@ -35,3 +35,10 @@
 .actions {
   justify-content: space-between;
 }
+
+.stretchedCard {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}


### PR DESCRIPTION
<!-- Add the number of the issue this pull request is closing here -->
Closes #245

<!-- Description of the changes this pull request introduces -->
**What change does this pull request introduce?**
sets same height for all algo cards in same row.

<!-- If applicable, include screenshots of the issue you solved -->
**Screenshots**
Before:
![Screenshot 2023-07-30 021130](https://github.com/TheAlgorithms/website/assets/64714761/9f9c4592-78be-41aa-b158-3f5d31fbb8e3)

After:
![Screenshot 2023-07-30 021254](https://github.com/TheAlgorithms/website/assets/64714761/4d6796d2-e2b0-4e14-85be-7fdd82a252bd)


**Checklist**

- [x] I worked on a branch other than `main`.
- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] I have fixed potential errors using `yarn lint`.
- [x] I ran `yarn build` to check everything still builds successfully.
