### PR TITLE
Fix fetching algorithms

### DIFF
--- a/lib/repositories.ts
+++ b/lib/repositories.ts
@@ -64,7 +64,7 @@ export const Repositories = {
   },
   r: {
     name: "R",
-    allowedFiles: [".R"],
+    allowedFiles: [".r"],
     baseDir: ".",
   },
   ruby: {

--- a/scripts/fetch-algorithms.ts
+++ b/scripts/fetch-algorithms.ts
@@ -550,10 +550,10 @@ const categoriesToSkip = ["main", "src", "algorithms", "problems"];
 function isValidCategory(name: string) {
   if (normalize(name).match(/problem\d+/)) return false;
   for (const exclude of categoriesToIgnore)
-    for (const category of name.split("/"))
+    for (const category of name.split(path.sep))
       if (normalize(category) === normalize(exclude)) return false;
   for (const exclude of ["__init__", "mod.rs"])
-    for (const category of name.split("/"))
+    for (const category of name.split(path.sep))
       if (category === exclude) return false;
   return true;
 }

--- a/scripts/fetch-algorithms.ts
+++ b/scripts/fetch-algorithms.ts
@@ -73,7 +73,7 @@ const categoriesToSkip = ["main", "src", "algorithms", "problems"];
       (repo) =>
         new Promise<void>((resolve, reject) => {
           exec(
-            `git clone https://github.com/TheAlgorithms/${repo}.git`,
+            `git clone --depth 1 https://github.com/TheAlgorithms/${repo}.git`,
             (err) => {
               if (err) reject(err);
               else resolve();


### PR DESCRIPTION
<!-- Description of the changes this pull request introduces -->
**What change does this pull request introduce?**

This PR fixes a few issues related to fetching algorithms:
- `name.split('/')` does not work for paths on windows. Replaced by the cross-platform `name.split(path.sep)`
- shallow cloning git repos saves time and network:
  `git clone --depth 1 https://github.com/TheAlgorithms/${repo}.git`
- R algorithms were not fetched. Fixed. These now can run using LiveCodes (#269)


**Checklist**

- [x] I worked on a branch other than `main`.
- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] I have fixed potential errors using `yarn lint`.
- [x] I ran `yarn build` to check everything still builds successfully.
