### PR TITLE
Change `margin-left` & `margin-right` properties to fix a bug with RTL languages

### DIFF
--- a/pages/language/style.module.css
+++ b/pages/language/style.module.css
@@ -5,9 +5,9 @@
 }
 
 .titleContainer > div > a {
-  margin-left: 20px !important;
+  margin-inline-start: 20px !important;
 }
 
 .icon {
-  margin-right: 12px;
+  margin-inline-end: 12px;
 }


### PR DESCRIPTION
<!-- Add the number of the issue this pull request is closing here -->
Closes #286

**What change does this pull request introduce?**

Replaces the properties `margin-left` and `margin-right` of the icon and the buttons links inside title container 
section in language page with `margin-inline-start` and `margin-inline-end`, because when `direction` property 
of the icon and buttons links changed to "rtl", `margin-inline-start` and `margin-inline-end` change margins 
directions of the icon and buttons links to suit the "rtl" direction, Unlike `margin-left` and `margin-right` 
that keep the margins in one direction even if the direction of the icon and buttons links changed.

**Screenshots**

before changes: 

![Screenshot (54)](https://github.com/TheAlgorithms/website/assets/115079247/7ddfa54b-a0d4-45c8-bbe3-d14a0b4657b0)

After changes: 

![Screenshot (55)](https://github.com/TheAlgorithms/website/assets/115079247/e5db15bf-e2de-44ad-a223-533cbdd45351)

**Checklist**

- [x] I worked on a branch other than `main`.
- [x] I have fixed potential errors using `yarn lint`.
- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] I ran `yarn build` to check everything still builds successfully.
