### PR TITLE
upgrade LiveCodes playground

### DIFF
--- a/components/playgroundEditor/LiveCodes.tsx
+++ b/components/playgroundEditor/LiveCodes.tsx
@@ -100,6 +100,7 @@ export default function LiveCodes({
       script: {
         language: "python-wasm",
         content: addTestRunner(pyCode),
+        title: "Python",
       },
     };
   };
@@ -124,6 +125,7 @@ export default function LiveCodes({
       script: {
         language: "python-wasm",
         content: getPyCode(jsonCode),
+        title: "Python",
       },
       tools: {
         enabled: ["console"],
@@ -175,6 +177,7 @@ ${test.replace(pattern, "\n")}`.trimStart();
         language: "lua-wasm",
         content,
         hiddenContent: luaTestRunner,
+        title: "Lua",
       },
     };
   };
@@ -185,6 +188,7 @@ ${test.replace(pattern, "\n")}`.trimStart();
     script: {
       language: "php-wasm",
       content: phpCode,
+      title: "PHP",
     },
     tools: {
       enabled: ["console"],
@@ -199,6 +203,7 @@ ${test.replace(pattern, "\n")}`.trimStart();
     script: {
       language: "cpp-wasm",
       content: cCode,
+      title: "C",
     },
   });
 
@@ -223,7 +228,7 @@ ${test.replace(pattern, "\n")}`.trimStart();
 
   return (
     <LiveCodesPlayground
-      appUrl="https://v19.livecodes.io/"
+      appUrl="https://v34.livecodes.io/"
       loading="eager"
       config={config}
       style={{ borderRadius: "0", resize: "none" }}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "highlight.js": "^11.5.1",
     "iframe-resizer-react": "^1.1.0",
     "katex": "^0.13.24",
-    "livecodes": "0.3.0",
+    "livecodes": "0.6.0",
     "marked": "^4.0.17",
     "next": "^12.1.0",
     "next-i18next": "^8.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2996,10 +2996,10 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-livecodes@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/livecodes/-/livecodes-0.3.0.tgz#95523234f25ecbf338de3e58d4a8e6c0fc05350f"
-  integrity sha512-bRD9TbWCEDAXfXIzqSSgTmlwHZtMjyrqg4uwULPwIdq8ozaFRVZnIEugvNh8PivpkryWN8OgfVknsNukMov43w==
+livecodes@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/livecodes/-/livecodes-0.6.0.tgz#3ad0d4361f6615cea62b8d40acfa33a892d1542f"
+  integrity sha512-nUqS6yy3NAKhVw+wt6yLKiqKSNbpbaJddI+KgtpMeQuIclBZbvhXK/enF8w/vQfxODPf5tmXkq765DIDxwTLTA==
 
 locate-path@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
<!-- Description of the changes this pull request introduces -->
**What change does this pull request introduce?**

This PR upgrades the [LiveCodes](https://github.com/live-codes/livecodes) playground & [SDK](https://www.npmjs.com/package/livecodes) to latest releases. See [changelog](https://github.com/live-codes/livecodes/releases) for details.

Most notablely, the main new features include:
- update compilers to latest releases.
- custom editor title (e.g. instead of `Py (Wasm)` now displays `Python`).
- responsive layout (vertical/horizontal) improves mobile experience (see screenshots below).
- significant improvements in JS/TS editor support on mobile with autocomplete, hover hints and errors.
- add support for [TypeScript twoslash](https://github.com/microsoft/TypeScript-Website/tree/v2/packages/ts-twoslasher) type comments.
- lots of more improvements and bug fixes. See [changelog](https://github.com/live-codes/livecodes/releases).


<!-- If applicable, include screenshots of the issue you solved -->
**Screenshots**

Desktop - light mode
![Screenshot 2024-07-28 102231](https://github.com/user-attachments/assets/171cb279-3b3d-432c-9e3d-c3404bd23965)

Desktop - dark mode
![Screenshot 2024-07-28 102437](https://github.com/user-attachments/assets/b02dd1e1-9b86-4dac-be3d-66c0474afc37)

Mobile - portrait
![Screenshot 2024-07-28 101701](https://github.com/user-attachments/assets/d6113c30-2846-4f64-b338-890df5ebb91b)

Mobile - landscape
![Screenshot 2024-07-28 101742](https://github.com/user-attachments/assets/99e8f877-dff1-47b8-bbd7-f813aed81a41)


**Checklist**

- [x] I worked on a branch other than `main`.
- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] I have fixed potential errors using `yarn lint`.
- [x] I ran `yarn build` to check everything still builds successfully.
