### PR TITLE
LiveCodes theme color & i18n

### DIFF
--- a/components/playgroundEditor/LiveCodes.tsx
+++ b/components/playgroundEditor/LiveCodes.tsx
@@ -234,7 +234,7 @@ ${test.replace(pattern, "\n")}`.trimStart();
 
   return (
     <LiveCodesPlayground
-      appUrl="https://v38.livecodes.io/"
+      appUrl="https://v39.livecodes.io/"
       loading="eager"
       config={config}
       style={{ borderRadius: "0", resize: "none" }}

--- a/components/playgroundEditor/LiveCodes.tsx
+++ b/components/playgroundEditor/LiveCodes.tsx
@@ -3,6 +3,7 @@ import type { Config, Playground } from "livecodes";
 import LiveCodesPlayground from "livecodes/react";
 import { luaTestRunner, type Language } from "lib/playground/livecodes";
 import { useDarkTheme } from "hooks/darkTheme";
+import { useRouter } from "next/router";
 
 export default function LiveCodes({
   language,
@@ -15,6 +16,14 @@ export default function LiveCodes({
 }) {
   const [playground, setPlayground] = useState<Playground | undefined>();
   const [darkTheme] = useDarkTheme();
+  const { locale } = useRouter();
+
+  const getLanguageFromLocale = (locale_: string | undefined) =>
+    !locale_
+      ? "en"
+      : locale_ === "zh_Hans"
+      ? "zh-CN"
+      : (locale_.split("_")[0] as Config["appLanguage"]);
 
   const onReady = (sdk: Playground) => {
     setPlayground(sdk);
@@ -31,6 +40,7 @@ export default function LiveCodes({
   }, [playground, darkTheme]);
 
   const baseConfig: Partial<Config> = {
+    appLanguage: getLanguageFromLocale(locale),
     autoupdate: true,
     languages: [language === "jupyter" ? "python-wasm" : language],
     script: {
@@ -224,7 +234,7 @@ ${test.replace(pattern, "\n")}`.trimStart();
 
   return (
     <LiveCodesPlayground
-      appUrl="https://v37.livecodes.io/"
+      appUrl="https://v38.livecodes.io/"
       loading="eager"
       config={config}
       style={{ borderRadius: "0", resize: "none" }}

--- a/components/playgroundEditor/LiveCodes.tsx
+++ b/components/playgroundEditor/LiveCodes.tsx
@@ -42,6 +42,7 @@ export default function LiveCodes({
       active: "console",
       status: "full",
     },
+    themeColor: "hsl(205, 17%, 50%)", // the original theme color is "#3a4852" which is "hsl(205, 17%, 27%)"
   };
 
   const getJSTSConfig = (
@@ -223,7 +224,7 @@ ${test.replace(pattern, "\n")}`.trimStart();
 
   return (
     <LiveCodesPlayground
-      appUrl="https://v34.livecodes.io/"
+      appUrl="https://v37.livecodes.io/"
       loading="eager"
       config={config}
       style={{ borderRadius: "0", resize: "none" }}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "highlight.js": "^11.5.1",
     "iframe-resizer-react": "^1.1.0",
     "katex": "^0.13.24",
-    "livecodes": "0.7.1",
+    "livecodes": "0.7.2",
     "marked": "^4.0.17",
     "next": "^12.1.0",
     "next-i18next": "^8.10.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "highlight.js": "^11.5.1",
     "iframe-resizer-react": "^1.1.0",
     "katex": "^0.13.24",
-    "livecodes": "0.6.0",
+    "livecodes": "0.7.1",
     "marked": "^4.0.17",
     "next": "^12.1.0",
     "next-i18next": "^8.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2996,10 +2996,10 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-livecodes@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/livecodes/-/livecodes-0.7.1.tgz#cac585d84935cbb94e47894285ad32dc1114acca"
-  integrity sha512-YHks/nvcgHPa1YmK7l1LWnaCOQZAlsour1nrUpk3ZGpXOHmkh0V4MbNB8pW+m3u8mGMON3xlhtWEq2+0KYYs0w==
+livecodes@0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/livecodes/-/livecodes-0.7.2.tgz#117bea6a171e677a49958dc52d21e96ca6aa8bea"
+  integrity sha512-9u8s+/mOztX6Ll1ru1Tpv2V8Ctb5TRprxXxyhl4U71nUPQIgaGt5ZiwTdRg4HofPiEKsdC1drTnAi9gNL3XRhA==
 
 locate-path@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2996,10 +2996,10 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-livecodes@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/livecodes/-/livecodes-0.6.0.tgz#3ad0d4361f6615cea62b8d40acfa33a892d1542f"
-  integrity sha512-nUqS6yy3NAKhVw+wt6yLKiqKSNbpbaJddI+KgtpMeQuIclBZbvhXK/enF8w/vQfxODPf5tmXkq765DIDxwTLTA==
+livecodes@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/livecodes/-/livecodes-0.7.1.tgz#cac585d84935cbb94e47894285ad32dc1114acca"
+  integrity sha512-YHks/nvcgHPa1YmK7l1LWnaCOQZAlsour1nrUpk3ZGpXOHmkh0V4MbNB8pW+m3u8mGMON3xlhtWEq2+0KYYs0w==
 
 locate-path@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
<!-- Description of the changes this pull request introduces -->
**What change does this pull request introduce?**

This PR updates LiveCodes playground to use the new features which include:
- UI update: which now supports specifying custom [theme color](https://livecodes.io/docs/features/themes/) to match the website design.
- [i18n support](https://livecodes.io/docs/features/i18n): LiveCodes now supports 12 UI languages which include: English, Arabic, Simplified Chinese, French, German, Hindi, Italian, Japanese, Portuguese, Russian, Spanish and Urdu. If a language is not supported, it falls back to English.

<!-- If applicable, include screenshots of the issue you solved -->
**Screenshots**

![Code-Playground-The-Algorithms-12-22-2024_12_19_PM](https://github.com/user-attachments/assets/ecc9d704-6154-443d-9fd7-268d33ea758d)

![Code-Playground-The-Algorithms-12-22-2024_12_24_PM](https://github.com/user-attachments/assets/46e5664c-3116-4c39-95f0-096a08fb4d8c)

![Code-Playground-The-Algorithms-12-22-2024_12_24_PM (1)](https://github.com/user-attachments/assets/fc409c22-84e0-4fc9-a046-4f2acbaaa191)

![Screenshot 2024-12-22 122210](https://github.com/user-attachments/assets/0c06e47a-328f-48ce-be00-88c204924c0d)


**Checklist**

- [x] I worked on a branch other than `main`.
- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] I have fixed potential errors using `yarn lint`.
- [x] I ran `yarn build` to check everything still builds successfully.
